### PR TITLE
use ENDPOINT_URL instead of localhost

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -5,8 +5,9 @@ import * as fs from 'fs';
 import { web3 } from "@project-serum/anchor";
 
 export async function main() {
-    const connection = new Connection('http://localhost:8899', 'confirmed');
-    console.log('Connecting to cluster')
+    const endpoint = process.env.ENDPOINT_URL || 'http://localhost:8899';
+    const connection = new Connection(endpoint, 'confirmed');
+    console.log('Connecting to cluster ' + endpoint)
     const authority = Keypair.generate();
 
 


### PR DESCRIPTION
It is useful to be able to configure `ENDPOINT_URL` for index.ts similar to `keeper.ts`.
One thing is that with quic enabled one must use `export ENDPOINT_URL=http://0.0.0.0:8899` and another is it simplifies configuration for testnet